### PR TITLE
New algorithm for Night-to-Day Bulb-Ramping

### DIFF
--- a/src/light.h
+++ b/src/light.h
@@ -2,9 +2,16 @@
 #define I2C_ADDR_WRITE  0b10001000
 
 #define LIGHT_INTEGRATION_COUNT 32
-#define FILTER_LENGTH 3
 
-#define NIGHT_THRESHOLD 20
+//nightEv() has same array size as iev(LIGHT_INTEGRATION_COUNT) 
+#define NIGHT_INTEGRATION_COUNT 32								//J.R. 9-30-15
+//338 is the number of seconds between updates to nightEv()
+//so the 32 readings in nightEv(NIGHT_INTEGRATION_COUNT) will span the previous 3 hours
+#define NIGHT_COUNT_DELAY 338									//J.R. 9-30-15
+
+#define FILTER_LENGTH 3
+//This definition isn't needed because it is a settable parameter
+//define NIGHT_THRESHOLD 20										//J.R. 10-11-15
 #define NIGHT_THRESHOLD_HYSTERESIS 5
 #define OFFSET_UNSET 65535
 
@@ -21,6 +28,8 @@ public:
 	void setRangeAuto();
 	float readEv();
 	float readIntegratedEv();
+	//This is the function that determines the best EV value for middle-of-the-night darkness.
+	float readNightEv();													//J.R. 9-30-15
 	float readIntegratedSlope();
 	float readIntegratedSlopeMedian();
 	void integrationStart(uint8_t integration_minutes);
@@ -32,11 +41,16 @@ public:
 
 private:
     float iev[LIGHT_INTEGRATION_COUNT];
+    //This is an array that contains 32 light readings spanned over the last 3 hours
+	float nightEv[NIGHT_INTEGRATION_COUNT];									//J.R. 9-30-15
     float filter[FILTER_LENGTH];
     int8_t filterIndex;
     int8_t wasPaused;
     uint16_t integration;
     uint32_t lastSeconds;
+    //This is the seconds timer value that decides when to put a new value in nightEv().
+	//This variable is similar to "lastSeconds" for updating iev().									
+	uint32_t nightSeconds;														//J.R. 9-30-15
     uint8_t initialized;
     uint16_t offset;
     bool integrationActive;

--- a/src/shutter.h
+++ b/src/shutter.h
@@ -217,6 +217,10 @@ public:
     int8_t rampRate, apertureEvShift;
     uint32_t last_photo_ms;
     float lightReading;
+	//This variable is the precise median/average EV value for the darkest part of the night 
+	float nightLight;																		//J.R. 11-30-15
+	//This flag maintains night2day bulb ramping once the light reaches a certain point		
+	bool Night2Day;																			//J.R. 10-11-15
     float pastErrors[PAST_ERROR_COUNT];
     volatile uint8_t paused, pausing, apertureReady;
     int8_t evShift;


### PR DESCRIPTION
This algorithm is based on a new rotating buffer similar to iev() that stores light readings over the three hour span at night just before dawn. This buffer is named nightEv(), and is the same size as iev() but light readings are added at a much slower rate to extend it to 3 hours, instead of the integration span. The arrayMedian50() function will then capture a precise level of EV for the darkest part of the night.

If the user starts the TL+ just before dawn, the entire nightEv() array is initialized with the current darkness EV value. It was also necessay to add the following statement to the code when starting bulb-ramping in the dark: lightReading = status.lightStart_f = status.nightTarget_i8, so these values are not set to: light.readIntegratedEv().

In the “RUN_BULB” routine, the algorithm detects when the average light starts going a certain amount above the calculated darkness level (nightLight), and normal bulb-ramping starts from that point. Many flags and condition were added to make sure the time of the sunrise was valid, and then  bulb-ramping should continue without interruption until full daylight or whenever.